### PR TITLE
new xslts for update.php; new order in index.php

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -18,26 +18,15 @@ $zip->extractTo($tmp . '/input');
 
 $steps = [
     [
-        'xsl/docx-html-extract.xsl',
+        'xsl/EXTRACT-docx.xsl',
         $tmp . '/input/word/document.xml',
         $outputFile
     ],
-    'xsl/handle-notes.xsl',
-    'xsl/join-elements.xsl',
-    'xsl/scrub.xsl',
-    'xsl/collapse-paragraphs.xsl',
-    [
-        'xsl/digest-paragraphs.xsl',
-        $outputFile,
-        $tmp . '/paragraphs.xml'
-    ],
-    [
-        'xsl/make-header-escalator-xslt.xsl',
-        $tmp . '/paragraphs.xml',
-        $tmp . '/header-escalator.xsl'
-    ],
-    $tmp . '/header-escalator.xsl',
+    'xsl/hyperlink-inferencer.xsl',
+    'xsl/PROMOTE-lists.xsl',
+    'xsl/header-promotion-CHOOSE.xsl',
     'xsl/final-rinse.xsl',
+    'xsl/editoria-tune.xsl'
     'xsl/p-split-around-br.xsl',
     'xsl/editoria-notes.xsl',
     'xsl/editoria-basic.xsl',

--- a/update.php
+++ b/update.php
@@ -5,20 +5,39 @@ if (php_sapi_name() !== 'cli') {
 }
 
 $urls = [
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/docx-extract/collapse-paragraphs.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/docx-extract/docx-html-extract.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/docx-extract/handle-notes.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/docx-extract/join-elements.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/docx-extract/scrub.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/html-polish/final-rinse.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/list-promote/itemize-lists.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/list-promote/mark-lists.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/header-promote/make-header-escalator-xslt.xsl',
-    'https://gitlab.coko.foundation/XSweet/XSweet/raw/ink-api-publish/applications/header-promote/digest-paragraphs.xsl',
-    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/ink-api-publish/p-split-around-br.xsl',
-    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/ink-api-publish/editoria-notes.xsl',
-    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/ink-api-publish/editoria-basic.xsl',
-    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/ink-api-publish/editoria-reduce.xsl',
+    // extract
+    'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/EXTRACT-docx.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/docx-html-extract.xsl',
+        'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/docx-table-extract.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/handle-notes.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/scrub.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/join-elements.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/docx-extract/collapse-paragraphs.xsl',
+
+    // links
+    'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/local-fixup/hyperlink-inferencer.xsl',
+
+    // lists
+    'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/list-promote/PROMOTE-lists.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/list-promote/itemize-lists.xsl',
+      'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/list-promote/mark-lists.xsl',
+
+    // header choose and promote
+    'https://gitlab.coko.foundation/XSweet/HTMLevator/raw/master/applications/header-promote/header-promotion-CHOOSE.xsl',
+      'https://gitlab.coko.foundation/XSweet/HTMLevator/raw/master/applications/header-promote/make-header-mapper-xslt.xsl',
+      'https://gitlab.coko.foundation/XSweet/HTMLevator/raw/master/applications/header-promote/outline-headers.xsl',
+      'https://gitlab.coko.foundation/XSweet/HTMLevator/raw/master/applications/header-promote/digest-paragraphs.xsl',
+      'https://gitlab.coko.foundation/XSweet/HTMLevator/raw/master/applications/header-promote/make-header-escalator-xslt.xsl',
+
+    // rinse
+    'https://gitlab.coko.foundation/XSweet/XSweet/raw/master/applications/html-polish/final-rinse.xsl',
+
+    // ucp cleanup macro and typescript
+    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/master/editoria-tune.xsl',
+    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/master/p-split-around-br.xsl',
+    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/master/editoria-notes.xsl',
+    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/master/editoria-basic.xsl',
+    'https://gitlab.coko.foundation/XSweet/editoria_typescript/raw/master/editoria-reduce.xsl',
 ];
 
 $outputDir = '/var/www/html/xsl';


### PR DESCRIPTION
Hi Alf, here's my latest update to the order of these xslts. I haven't been able to run this, since i get docker errors trying to install and run the latest INK, and also it looks like the php needs to be running somewhere anyway. The biggest question is whether xslts can be run from inside xslts: the indentation in the update.php xslt urls reflect each sheet's dependencies.